### PR TITLE
Add a Embed module

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,6 +7,7 @@
     "exposed-modules": [
         "Element.WithContext",
         "Element.WithContext.Input",
+        "Element.WithContext.Embed",
         "Element.WithContext.Events",
         "Element.WithContext.Background",
         "Element.WithContext.Border",

--- a/src/Element/WithContext.elm
+++ b/src/Element/WithContext.elm
@@ -1,5 +1,5 @@
 module Element.WithContext exposing
-    ( with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr
+    ( with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr, embed, embedAttr
     , Element, none, text, el
     , row, wrappedRow, column
     , paragraph, textColumn
@@ -31,7 +31,7 @@ module Element.WithContext exposing
 
 # `elm-ui-with-context` specific functions
 
-@docs with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr
+@docs with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr, embed, embedAttr
 
 
 # Basic Elements
@@ -367,6 +367,50 @@ attribute elem =
 attr : Element.Attr decorative msg -> Attr context decorative msg
 attr elem =
     Attribute <| \_ -> elem
+
+
+{-| Allow integration with external libraries that require elm-ui `Element`s to be passed in.
+-}
+embed :
+    ({ unwrap : Element context msg -> Element.Element msg
+     , unwrapAttr : Attr context decorative msg -> Element.Attr decorative msg
+     }
+     -> Element context msg
+    )
+    -> Element context msg
+embed ctor =
+    Element <|
+        \context ->
+            let
+                (Element result) =
+                    ctor
+                        { unwrap = \(Element f) -> f context
+                        , unwrapAttr = \(Attribute f) -> f context
+                        }
+            in
+            result context
+
+
+{-| Allow integration with external libraries that require elm-ui `Element`s to be passed in.
+-}
+embedAttr :
+    ({ unwrap : Element context msg -> Element.Element msg
+     , unwrapAttr : Attr context decorative msg -> Element.Attr decorative msg
+     }
+     -> Attr context decorative msg
+    )
+    -> Attr context decorative msg
+embedAttr ctor =
+    Attribute <|
+        \context ->
+            let
+                (Attribute result) =
+                    ctor
+                        { unwrap = \(Element f) -> f context
+                        , unwrapAttr = \(Attribute f) -> f context
+                        }
+            in
+            result context
 
 
 {-| -}

--- a/src/Element/WithContext.elm
+++ b/src/Element/WithContext.elm
@@ -1,5 +1,5 @@
 module Element.WithContext exposing
-    ( with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr, embed, embedAttr
+    ( with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr
     , Element, none, text, el
     , row, wrappedRow, column
     , paragraph, textColumn
@@ -31,7 +31,7 @@ module Element.WithContext exposing
 
 # `elm-ui-with-context` specific functions
 
-@docs with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr, embed, embedAttr
+@docs with, withAttribute, withDecoration, layout, layoutWith, element, attribute, attr
 
 
 # Basic Elements
@@ -367,50 +367,6 @@ attribute elem =
 attr : Element.Attr decorative msg -> Attr context decorative msg
 attr elem =
     Attribute <| \_ -> elem
-
-
-{-| Allow integration with external libraries that require elm-ui `Element`s to be passed in.
--}
-embed :
-    ({ unwrap : Element context msg -> Element.Element msg
-     , unwrapAttr : Attr context decorative msg -> Element.Attr decorative msg
-     }
-     -> Element context msg
-    )
-    -> Element context msg
-embed ctor =
-    Element <|
-        \context ->
-            let
-                (Element result) =
-                    ctor
-                        { unwrap = \(Element f) -> f context
-                        , unwrapAttr = \(Attribute f) -> f context
-                        }
-            in
-            result context
-
-
-{-| Allow integration with external libraries that require elm-ui `Element`s to be passed in.
--}
-embedAttr :
-    ({ unwrap : Element context msg -> Element.Element msg
-     , unwrapAttr : Attr context decorative msg -> Element.Attr decorative msg
-     }
-     -> Attr context decorative msg
-    )
-    -> Attr context decorative msg
-embedAttr ctor =
-    Attribute <|
-        \context ->
-            let
-                (Attribute result) =
-                    ctor
-                        { unwrap = \(Element f) -> f context
-                        , unwrapAttr = \(Attribute f) -> f context
-                        }
-            in
-            result context
 
 
 {-| -}

--- a/src/Element/WithContext/Embed.elm
+++ b/src/Element/WithContext/Embed.elm
@@ -1,0 +1,103 @@
+module Element.WithContext.Embed exposing
+    ( el, attr
+    , unwrap, unwrapAttr, unwrapLabel, unwrapOption, unwrapPlaceholder, unwrapThumb
+    )
+
+{-|
+
+@docs el, attr
+
+-}
+
+import Element
+import Element.Input
+import Element.WithContext.Input.Internal as Internal exposing (Label(..), Option(..), Placeholder(..), Thumb(..), runLabel, runOption, runPlaceholder, runThumb)
+import Element.WithContext.Internal as Internal exposing (Attr(..), Element(..), run, runAttr)
+
+
+unwrap =
+    Internal.run
+
+
+unwrapAttr =
+    Internal.runAttr
+
+
+unwrapLabel =
+    Internal.runLabel
+
+
+unwrapOption =
+    Internal.runOption
+
+
+unwrapPlaceholder =
+    Internal.runPlaceholder
+
+
+unwrapThumb =
+    Internal.runThumb
+
+
+{-| Allow integration with external libraries that require elm-ui `Element`s to be passed in.
+-}
+el :
+    ({ context : context
+     , unwrap : Element context msg -> Element.Element msg
+     , unwrapAttr : Attr context decorative msg -> Element.Attr decorative msg
+     , unwrapPlaceholder : Placeholder context msg -> Element.Input.Placeholder msg
+     , unwrapLabel : Label context msg -> Element.Input.Label msg
+     , unwrapThumb : Thumb context -> Element.Input.Thumb
+     , unwrapOption : Option context value msg -> Element.Input.Option value msg
+     }
+     -> Element context msg
+    )
+    -> Element context msg
+el ctor =
+    Element <|
+        \context ->
+            let
+                (Element result) =
+                    ctor
+                        { context = context
+                        , unwrap = \(Element f) -> f context
+                        , unwrapAttr = \(Attribute f) -> f context
+                        , unwrapPlaceholder = \(Placeholder f) -> f context
+                        , unwrapLabel = \(Label f) -> f context
+                        , unwrapThumb = \(Thumb f) -> f context
+                        , unwrapOption = \(Option f) -> f context
+                        }
+            in
+            result context
+
+
+{-| Allow integration with external libraries that require elm-ui `Element`s to be passed in.
+-}
+attr :
+    ({ context : context
+     , unwrap : Element context msg -> Element.Element msg
+     , unwrapAttr : Attr context decorative msg -> Element.Attr decorative msg
+     , unwrapPlaceholder : Placeholder context msg -> Element.Input.Placeholder msg
+     , unwrapLabel : Label context msg -> Element.Input.Label msg
+     , unwrapThumb : Thumb context -> Element.Input.Thumb
+     , unwrapOption : Option context value msg -> Element.Input.Option value msg
+     }
+     -> Attr context decorative msg
+    )
+    -> Attr context decorative msg
+attr ctor =
+    Attribute <|
+        \context ->
+            let
+                (Attribute result) =
+                    ctor
+                        { context = context
+                        , unwrap = \(Element f) -> f context
+                        , unwrapAttr = \(Attribute f) -> f context
+                        , unwrapPlaceholder = \(Placeholder f) -> f context
+                        , unwrapLabel = \(Label f) -> f context
+                        , unwrapThumb = \(Thumb f) -> f context
+                        , unwrapOption = \(Option f) -> f context
+                        }
+            in
+            result context

--- a/src/Element/WithContext/Input.elm
+++ b/src/Element/WithContext/Input.elm
@@ -187,12 +187,13 @@ Alternatively, see if it's reasonable to _not_ display an input if you'd normall
 import Element as Vanilla
 import Element.Input as Input
 import Element.WithContext exposing (Attribute, Element, element)
+import Element.WithContext.Input.Internal as InputInternal exposing (Label(..), Option(..), Placeholder(..), Thumb(..), runLabel, runOption, runPlaceholder, runThumb)
 import Element.WithContext.Internal exposing (attribute, attributes, run, wrapAttrs)
 
 
 {-| -}
-type Placeholder context msg
-    = Placeholder (context -> Input.Placeholder msg)
+type alias Placeholder context msg =
+    InputInternal.Placeholder context msg
 
 
 {-| -}
@@ -205,8 +206,8 @@ placeholder attrs child =
 
 
 {-| -}
-type Label context msg
-    = Label (context -> Input.Label msg)
+type alias Label context msg =
+    InputInternal.Label context msg
 
 
 buildLabel :
@@ -333,20 +334,14 @@ checkbox =
         )
 
 
-{-| -}
-type Thumb context
-    = Thumb (context -> Input.Thumb)
+type alias Thumb context =
+    InputInternal.Thumb context
 
 
 {-| -}
 thumb : List (Attribute context Never) -> Thumb context
 thumb attrs =
     Thumb <| \context -> Input.thumb <| attributes context attrs
-
-
-runThumb : a -> Thumb a -> Input.Thumb
-runThumb context (Thumb f) =
-    f context
 
 
 {-| -}
@@ -452,16 +447,6 @@ textHelper f =
             , placeholder = Maybe.map (runPlaceholder context) config.placeholder
             }
         )
-
-
-runPlaceholder : context -> Placeholder context msg -> Input.Placeholder msg
-runPlaceholder context (Placeholder f) =
-    f context
-
-
-runLabel : context -> Label context msg -> Input.Label msg
-runLabel context (Label f) =
-    f context
 
 
 {-| -}
@@ -615,13 +600,8 @@ multiline =
 
 
 {-| -}
-type Option context value msg
-    = Option (context -> Input.Option value msg)
-
-
-runOption : a -> Option a value msg -> Input.Option value msg
-runOption context (Option f) =
-    f context
+type alias Option context value msg =
+    InputInternal.Option context value msg
 
 
 {-| -}

--- a/src/Element/WithContext/Input/Internal.elm
+++ b/src/Element/WithContext/Input/Internal.elm
@@ -1,0 +1,40 @@
+module Element.WithContext.Input.Internal exposing (Label(..), Option(..), Placeholder(..), Thumb(..), runLabel, runOption, runPlaceholder, runThumb)
+
+import Element.Input as Input
+
+
+type Placeholder context msg
+    = Placeholder (context -> Input.Placeholder msg)
+
+
+runPlaceholder : context -> Placeholder context msg -> Input.Placeholder msg
+runPlaceholder context (Placeholder f) =
+    f context
+
+
+type Label context msg
+    = Label (context -> Input.Label msg)
+
+
+runLabel : context -> Label context msg -> Input.Label msg
+runLabel context (Label f) =
+    f context
+
+
+type Option context value msg
+    = Option (context -> Input.Option value msg)
+
+
+runOption : a -> Option a value msg -> Input.Option value msg
+runOption context (Option f) =
+    f context
+
+
+{-| -}
+type Thumb context
+    = Thumb (context -> Input.Thumb)
+
+
+runThumb : a -> Thumb a -> Input.Thumb
+runThumb context (Thumb f) =
+    f context


### PR DESCRIPTION
This is an alternative to #8 based on the embed-api branch by @miniBill 

It exposes the 'run' functions directly in addition to the embed functions to deal with corner cases (mainly, having 2 different 'msg' types).